### PR TITLE
Fixes

### DIFF
--- a/src/compileCIL/CompilationContext.ts
+++ b/src/compileCIL/CompilationContext.ts
@@ -17,6 +17,7 @@ export class CompilationContext {
   constructor() {
     this.count = 0;
     this.vars = [];
+    this.cil = [];
   }
 
   getTag(): string {

--- a/src/parser/Grammar.ne
+++ b/src/parser/Grammar.ne
@@ -63,7 +63,7 @@ comp ->
   | comp "<" addsub         {% ([lhs, , rhs]) => (new CompareLess(lhs, rhs)) %}
   | comp ">=" addsub        {% ([lhs, , rhs]) => (new CompareGreatOrEqual(lhs, rhs)) %}
   | comp ">" addsub         {% ([lhs, , rhs]) => (new CompareGreat(lhs, rhs)) %}
-  | addsub
+  | addsub                  {% id %}
 
 addsub ->
     addsub "+" muldiv       {% ([lhs, , rhs]) => (new Addition(lhs, rhs)) %}


### PR DESCRIPTION
- the cil array wasn't initialized at the export class CompilationContext constructor
- a return value was missing at the grammar